### PR TITLE
fix(005): remove environment requirement from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # 超时保护
-    environment:
-      name: production
-      url: http://${{ secrets.ALIYUN_ECS_HOST }}:8000
+    # environment:  # 暂时注释，使用 Repository Secrets
+    #   name: production
+    #   url: http://${{ secrets.ALIYUN_ECS_HOST }}:8000
 
     steps:
       # Step 1: 检出代码

--- a/specs/005-github-ci-aliyun-deploy/tasks.md
+++ b/specs/005-github-ci-aliyun-deploy/tasks.md
@@ -122,8 +122,8 @@
 
 **Test Validation for US2**:
 - [x] T060 [US2] 手动执行首次部署验证 ECS 环境配置正确(参考 quickstart.md 第四步) ✅
-- [ ] T061 [US2] 创建测试 PR 并合并到 master 验证自动部署触发
-- [ ] T062 [US2] 验证部署成功并通过健康检查(检查 Actions 日志和 ECS 服务状态)
+- [x] T061 [US2] 创建测试 PR 并合并到 master 验证自动部署触发 ✅ (PR #3 已合并)
+- [ ] T062 [US2] 验证部署成功并通过健康检查(检查 Actions 日志和 ECS 服务状态) ⚠️ 需要修复 deploy.yml 配置
 - [ ] T063 [US2] 验证版本目录和符号链接正确创建(ssh 到 ECS 检查 /opt/diting/)
 - [ ] T064 [US2] 故意引入错误(如语法错误)验证回滚机制工作
 - [ ] T065 [US2] 快速连续合并两个 PR 验证串行执行(concurrency 配置)


### PR DESCRIPTION
## 问题

部署工作流立即失败，错误提示 'workflow file issue'。

## 原因分析

`deploy.yml` 中配置了 `environment: production`，但 GitHub 上没有创建对应的 Environment。

## 解决方案

暂时注释掉 `environment` 配置，直接使用已配置的 Repository Secrets：
- `ALIYUN_ECS_HOST`
- `ALIYUN_SSH_USER`
- `ALIYUN_SSH_PRIVATE_KEY`

Repository Secrets 对所有 workflows 可用，不需要 Environment 也能正常工作。

## 后续优化

如需 Environment 功能（部署审批、环境保护、部署历史），可以：
1. 在 GitHub Settings → Environments 创建 `production` environment
2. 取消注释 `environment` 配置
3. 无需重新配置 secrets（自动继承 Repository Secrets）

## 测试

- [x] 本地语法检查通过
- [ ] 等待 CI 测试通过
- [ ] 合并后验证部署工作流成功运行

Related: #3, T062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>