### PR TITLE
feat(005): change application port to 17999

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,11 +138,11 @@ jobs:
 
             # HTTP 健康检查
             for i in {1..30}; do
-              if curl -f http://localhost:8000/health > /dev/null 2>&1; then
+              if curl -f http://localhost:17999/health > /dev/null 2>&1; then
                 echo "✅ 健康检查通过"
 
                 # 验证 JSON 响应格式
-                HEALTH_RESPONSE=$(curl -s http://localhost:8000/health)
+                HEALTH_RESPONSE=$(curl -s http://localhost:17999/health)
                 if echo "$HEALTH_RESPONSE" | jq -e '.status == "healthy"' > /dev/null 2>&1; then
                   echo "✅ 健康检查响应格式正确"
                   exit 0

--- a/deploy/diting.service
+++ b/deploy/diting.service
@@ -19,7 +19,7 @@ WorkingDirectory=/opt/diting/current
 ExecStart=/opt/diting/current/.venv/bin/uvicorn \
     src.diting.endpoints.wechat.webhook_app:app \
     --host 0.0.0.0 \
-    --port 8000 \
+    --port 17999 \
     --log-level info \
     --access-log
 

--- a/specs/005-github-ci-aliyun-deploy/DEPLOYMENT_CONFIG.md
+++ b/specs/005-github-ci-aliyun-deploy/DEPLOYMENT_CONFIG.md
@@ -99,7 +99,7 @@ sudo systemctl enable --now firewalld
 sudo firewall-cmd --permanent --add-service=ssh
 sudo firewall-cmd --permanent --add-service=http
 sudo firewall-cmd --permanent --add-service=https
-sudo firewall-cmd --permanent --add-port=8000/tcp
+sudo firewall-cmd --permanent --add-port=17999/tcp
 sudo firewall-cmd --reload
 ```
 

--- a/specs/005-github-ci-aliyun-deploy/contracts/systemd-service.service
+++ b/specs/005-github-ci-aliyun-deploy/contracts/systemd-service.service
@@ -17,9 +17,9 @@ WorkingDirectory=/opt/diting/current
 
 # 启动命令
 ExecStart=/opt/diting/current/.venv/bin/uvicorn \
-    src.endpoints.wechat.webhook_app:app \
+    src.diting.endpoints.wechat.webhook_app:app \
     --host 0.0.0.0 \
-    --port 8000 \
+    --port 17999 \
     --log-level info \
     --access-log
 


### PR DESCRIPTION
## Summary

Change the application deployment port from 8000 to 17999 to align with production requirements.

## Changes

1. **Systemd service file** ([deploy/diting.service](deploy/diting.service))
   - ✅ Port: `8000` → `17999`
   - ✅ Module path: `src.diting.endpoints.wechat.webhook_app:app` (correct)

2. **Deploy workflow** ([.github/workflows/deploy.yml](.github/workflows/deploy.yml))
   - ✅ Health check port: `8000` → `17999`

3. **Firewall configuration** ([DEPLOYMENT_CONFIG.md](specs/005-github-ci-aliyun-deploy/DEPLOYMENT_CONFIG.md))
   - ✅ Firewall rule: `8000/tcp` → `17999/tcp`

4. **Service template** ([systemd-service.service](specs/005-github-ci-aliyun-deploy/contracts/systemd-service.service))
   - ✅ Port: `8000` → `17999`
   - ✅ Fixed module path: `src.diting.endpoints.wechat.webhook_app:app`

## Manual Configuration

**已手动完成** on ECS server:
- ✅ Updated `/etc/systemd/system/diting.service` to use port 17999
- ✅ Updated sudo permissions to allow service file updates
- ✅ Configured firewall to allow port 17999
- ✅ Service restarted and verified working

## Testing

After merge, the deployment workflow will:
1. ✅ Update service file with correct port (17999) and module path
2. ✅ Deploy new version to ECS
3. ✅ Health check on `http://localhost:17999/health`
4. ✅ Verify deployment success

## Related

- Resolves T062: 验证部署成功并通过健康检查
- Port change requirement from production environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)