### PR TITLE
fix(005): relax systemd security settings to resolve NAMESPACE error

### DIFF
--- a/deploy/diting.service
+++ b/deploy/diting.service
@@ -42,8 +42,8 @@ CPUQuota=100%
 # 安全加固
 NoNewPrivileges=true
 PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
+ProtectSystem=full
+ProtectHome=false
 ReadWritePaths=/opt/diting/current/logs
 
 # 日志配置

--- a/specs/005-github-ci-aliyun-deploy/contracts/systemd-service.service
+++ b/specs/005-github-ci-aliyun-deploy/contracts/systemd-service.service
@@ -42,8 +42,8 @@ CPUQuota=100%
 # 安全加固
 NoNewPrivileges=true
 PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
+ProtectSystem=full
+ProtectHome=false
 ReadWritePaths=/opt/diting/current/logs
 
 # 日志配置


### PR DESCRIPTION
## Problem

Deployment health checks were failing because the systemd service couldn't start, exiting with code 226/NAMESPACE error.

### Root Cause

The security hardening settings in the systemd service file were too restrictive:
- `ProtectSystem=strict` - Prevents writing to most of the filesystem
- `ProtectHome=true` - Blocks access to home directories

These settings caused the application to fail during startup with NAMESPACE errors.

## Solution

Relax the security settings while maintaining reasonable protection:

**Before**:
```ini
ProtectSystem=strict
ProtectHome=true
```

**After**:
```ini
ProtectSystem=full   # Still protects /usr, /boot, /efi, but allows /etc writes
ProtectHome=false    # Allows access needed by the application
```

**Maintained security**:
- ✅ `NoNewPrivileges=true` - Prevents privilege escalation
- ✅ `PrivateTmp=true` - Isolated /tmp directory
- ✅ Resource limits (Memory, CPU, file descriptors)
- ✅ Specific writable path: `/opt/diting/current/logs`

## Testing

**Manual test on ECS** (successful):
```bash
sudo cp /opt/diting/current/deploy/diting.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl restart diting
systemctl is-active diting  # ✅ active
curl http://localhost:17999/health  # ✅ {"status":"healthy"}
```

**Expected after merge**:
1. ✅ Deployment workflow updates service file with relaxed settings
2. ✅ Service starts successfully without NAMESPACE error
3. ✅ Health check passes on port 17999
4. ✅ Deployment completes successfully

## Changes

- [deploy/diting.service](deploy/diting.service): Update security settings
- [contracts/systemd-service.service](specs/005-github-ci-aliyun-deploy/contracts/systemd-service.service): Update template

## Related

- Resolves T062: 验证部署成功并通过健康检查
- Fixes exit code 226/NAMESPACE error in all previous deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)