### PR TITLE
fix(005): 修复 systemd 命名空间隔离导致的启动失败 (exit code 226)

### DIFF
--- a/deploy/diting.service
+++ b/deploy/diting.service
@@ -40,11 +40,12 @@ MemoryMax=1G
 CPUQuota=100%
 
 # 安全加固
+# 注意: 某些选项在容器或云环境中可能不兼容,已调整为兼容模式
 NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=full
+# PrivateTmp=true  # 禁用: 在某些环境中导致 exit code 226/NAMESPACE 错误
+# ProtectSystem=full  # 禁用: 可能与云环境不兼容
 ProtectHome=false
-ReadWritePaths=/opt/diting/current/logs
+# ReadWritePaths=/opt/diting/current/logs  # 移除: ProtectSystem 已禁用
 
 # 日志配置
 StandardOutput=journal


### PR DESCRIPTION
## 问题描述

PR #15 合并后,部署工作流中的健康检查再次失败。经过服务器日志分析,发现是 **systemd 服务无法启动**导致。

### 错误信息

```
× diting.service - Diting WeChat Webhook Service
     Active: failed (Result: exit-code)
    Process: 117535 ExecStart=... (code=exited, status=226/NAMESPACE)
```

**Exit Code 226/NAMESPACE** 表示 systemd 无法设置命名空间隔离。

### 根本原因

查看 `deploy/diting.service` 配置:

```systemd
# 安全加固
PrivateTmp=true          # ← 问题所在!
ProtectSystem=full
ReadWritePaths=/opt/diting/current/logs
```

**问题分析:**
1. `PrivateTmp=true` 要求创建私有的临时目录命名空间
2. 在阿里云 ECS 环境中,内核可能不支持或安全策略禁止此特性
3. 导致 systemd 启动服务时立即失败(exit code 226)
4. 触发 `StartLimitBurst` 保护,服务进入 failed 状态

### 时间线

1. **PR #15** - 修复健康检查逻辑(移除 systemd 状态前置检查)
2. **部署触发** - 合并后自动部署
3. **服务启动失败** - systemd 报告 exit code 226
4. **健康检查失败** - HTTP 端点无响应(因为服务根本没启动)
5. **自动回滚** - 回到旧版本

## 解决方案

### 修改内容

注释掉不兼容的 systemd 安全选项:

```diff
 # 安全加固
+# 注意: 某些选项在容器或云环境中可能不兼容,已调整为兼容模式
 NoNewPrivileges=true
-PrivateTmp=true
+# PrivateTmp=true  # 禁用: 在某些环境中导致 exit code 226/NAMESPACE 错误
-ProtectSystem=full
+# ProtectSystem=full  # 禁用: 可能与云环境不兼容
 ProtectHome=false
-ReadWritePaths=/opt/diting/current/logs
+# ReadWritePaths=/opt/diting/current/logs  # 移除: ProtectSystem 已禁用
```

### 安全影响评估

**保留的安全措施:**
- ✅ 服务以 `deploy` 非特权用户运行
- ✅ `NoNewPrivileges=true` 防止权限提升
- ✅ 资源限制: `MemoryMax=1G`, `CPUQuota=100%`, `LimitNOFILE=65536`
- ✅ 重启限制: `StartLimitBurst=5`, `StartLimitInterval=300`

**移除的安全措施:**
- ❌ `PrivateTmp=true` - 私有临时目录(换取兼容性)
- ❌ `ProtectSystem=full` - 系统目录只读保护(换取兼容性)
- ❌ `ReadWritePaths` - 明确的可写路径(已无需,因 ProtectSystem 禁用)

**结论:** 安全性略有降低,但服务仍在非特权用户下运行,核心安全措施保持生效。

## 测试验证

### 服务器手动验证步骤

1. **更新服务配置:**
   ```bash
   sudo cp /opt/diting/current/deploy/diting.service /etc/systemd/system/
   sudo systemctl daemon-reload
   ```

2. **重置启动限制:**
   ```bash
   sudo systemctl reset-failed diting
   ```

3. **启动服务:**
   ```bash
   sudo systemctl start diting
   sudo systemctl status diting
   ```

4. **验证健康检查:**
   ```bash
   curl http://localhost:17999/health
   ```

### 预期结果

- ✅ 服务成功启动,状态为 `active (running)`
- ✅ HTTP 健康检查返回 `{"status": "healthy"}`
- ✅ 部署工作流健康检查在 10 秒内通过
- ✅ 不再出现 exit code 226 错误

## 影响范围

- **修改文件:** `deploy/diting.service`
- **影响组件:** systemd 服务配置
- **向后兼容:** 完全兼容,不影响应用代码

## Checklist

- [x] 分析服务器日志确认 exit code 226 错误
- [x] 识别出 PrivateTmp 导致的命名空间问题
- [x] 注释掉不兼容的安全选项
- [x] 评估安全影响
- [x] 提交信息遵循 Conventional Commits
- [ ] 等待 CI 测试通过
- [ ] 部署后验证服务正常启动

## 相关 Issue/PR

- Closes #13 (Deploy Failed - 2025-11-03)
- Builds on #15 (健康检查逻辑修复)

🤖 Generated with [Claude Code](https://claude.com/claude-code)