### PR TITLE
fix(deploy): fix .env file creation in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,13 +97,11 @@ jobs:
       - name: Create .env configuration file
         run: |
           echo "::group::创建 .env 配置文件"
-          ssh ${{ secrets.ALIYUN_SSH_USER }}@${{ secrets.ALIYUN_ECS_HOST }} << 'EOF'
+          ssh ${{ secrets.ALIYUN_SSH_USER }}@${{ secrets.ALIYUN_ECS_HOST }} << EOF
             cd ${{ steps.create-release.outputs.RELEASE_DIR }}
 
             # 创建 .env 文件
-            cat > .env << 'ENVEOF'
-BASE_URL=${{ secrets.BASE_URL }}
-ENVEOF
+            echo "BASE_URL=${{ secrets.BASE_URL }}" > .env
 
             echo "✅ .env 配置文件已创建"
           EOF


### PR DESCRIPTION
## 问题描述

PR #26 合并后，部署工作流失败，原因是 .env 文件创建步骤中使用了错误的 heredoc 语法。

## 错误原因

在 SSH heredoc 中使用了单引号 `'EOF'`，导致 GitHub Actions 的 `${{ }}` 语法无法正确展开。

**错误代码**:
```yaml
ssh ... << 'EOF'
  cd ${{ steps.create-release.outputs.RELEASE_DIR }}
  cat > .env << 'ENVEOF'
BASE_URL=${{ secrets.BASE_URL }}
ENVEOF
EOF
```

## 修复方案

1. 移除 heredoc 的单引号，使用 `EOF` 而不是 `'EOF'`
2. 简化 .env 文件创建，使用 `echo` 命令而不是嵌套 heredoc

**修复后代码**:
```yaml
ssh ... << EOF
  cd ${{ steps.create-release.outputs.RELEASE_DIR }}
  echo "BASE_URL=${{ secrets.BASE_URL }}" > .env
EOF
```

## 测试

- ✅ YAML 语法验证通过
- ✅ 本地测试通过
- ⏳ 等待 CI 验证

## 影响范围

- 仅影响部署工作流的 .env 文件创建步骤
- 不影响其他功能
- 修复后部署将正常进行

## Checklist

- ✅ 修复了 heredoc 语法错误
- ✅ 简化了 .env 文件创建逻辑
- ✅ 提交信息符合规范

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>