### PR TITLE
fix(deploy): enable production environment for BASE_URL secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15  # 超时保护
-    # environment:  # 暂时注释，使用 Repository Secrets
-    #   name: production
-    #   url: http://${{ secrets.ALIYUN_ECS_HOST }}:8000
+    environment:
+      name: production
+      url: http://${{ secrets.ALIYUN_ECS_HOST }}:17999
 
     steps:
       # Step 1: 检出代码


### PR DESCRIPTION
## 问题描述

部署后 .env 文件中的 BASE_URL 为空，导致无法正确读取配置。

**服务器上的 .env 文件**:
```bash
[root@ECS current]# cat .env
BASE_URL=
```

## 根本原因

1. **BASE_URL secret 配置位置错误**:
   - BASE_URL 被添加到了 **production 环境** 的 secrets
   - 但部署工作流中 `environment: production` 被注释掉了
   - 导致工作流无法访问 production 环境的 secrets

2. **工作流配置**:
   ```yaml
   # environment:  # 暂时注释，使用 Repository Secrets
   #   name: production
   ```

3. **结果**:
   - `${{ secrets.BASE_URL }}` 解析为空字符串
   - .env 文件被创建但内容为空

## 解决方案

### 1. 启用 production 环境

```yaml
environment:
  name: production
  url: http://${{ secrets.ALIYUN_ECS_HOST }}:17999
```

### 2. 配置验证

**Production 环境 secrets**:
```bash
$ gh secret list --env production
BASE_URL	2026-01-23T13:27:54Z
```

**Production 环境 variables**:
```bash
$ gh variable list --env production
DATA_DIR	/data	2026-01-23T12:57:14Z
```

### 3. 预期结果

部署后 .env 文件内容:
```bash
BASE_URL=/opt/diting/data
```

## 变更内容

- ✅ 取消注释 `environment: production`
- ✅ 更新环境 URL 端口: 8000 → 17999
- ✅ 工作流现在可以访问 production secrets

## 测试计划

1. ✅ CI 测试通过
2. ⏳ 部署到 production
3. ⏳ 验证 .env 文件内容
4. ⏳ 验证服务正常运行

## 验证步骤

部署后在服务器上验证:

```bash
# 1. 检查 .env 文件
ssh deploy@ECS_IP "cat /opt/diting/current/.env"
# 预期输出: BASE_URL=/opt/diting/data

# 2. 检查服务状态
ssh deploy@ECS_IP "systemctl status diting"

# 3. 检查健康检查
curl http://ECS_IP:17999/health
# 预期输出: {"status": "healthy"}
```

## 相关 Issue

- 修复 PR #26 引入的配置问题
- 确保环境变量配置功能正常工作

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>