### PR TITLE
feat(cli): add download command for general file download

### DIFF
--- a/config/wechat.yaml.example
+++ b/config/wechat.yaml.example
@@ -3,6 +3,7 @@
 
 api:
   base_url: "https://chat-api.juhebot.com/open/GuidRequest"
+  cloud_base_url: "http://host:port/"  # Cloud API (用于 /cloud 开头的接口)
   app_key: "YOUR_APP_KEY_HERE"
   app_secret: "YOUR_APP_SECRET_HERE"
 

--- a/src/diting/endpoints/wechat/client.py
+++ b/src/diting/endpoints/wechat/client.py
@@ -43,6 +43,7 @@ class WeChatAPIClient(EndpointAdapter):
         """
         self.config = config
         self.base_url = config.api.base_url
+        self.cloud_base_url = config.api.cloud_base_url
 
         # 配置 HTTP 客户端超时
         timeout = httpx.Timeout(
@@ -226,6 +227,9 @@ class WeChatAPIClient(EndpointAdapter):
         自动获取 CDN 信息作为 base_request，然后调用下载 API。
         适用于 30 开头的文件 ID。
 
+        注意: /cloud 开头的 API 使用不同的调用方式,直接 POST JSON body,
+        不需要 app_key/app_secret 包装。
+
         Args:
             guid: 设备 GUID
             aes_key: AES 解密密钥
@@ -255,11 +259,10 @@ class WeChatAPIClient(EndpointAdapter):
             "username": cdn_data.get("username", ""),
         }
 
-        # 构建下载请求
-        request = self._build_request(
+        # Cloud API 直接 POST JSON body,不需要 app_key/app_secret 包装
+        response_data = self._send_cloud_request(
             path="/cloud/download",
             data={
-                "guid": guid,
                 "base_request": base_request,
                 "aes_key": aes_key,
                 "file_id": file_id,
@@ -267,9 +270,86 @@ class WeChatAPIClient(EndpointAdapter):
                 "file_type": file_type,
             },
         )
-
-        response_data = self._send_request(request)
         return response_data
+
+    def _send_cloud_request(self, path: str, data: dict[str, Any]) -> dict[str, Any]:
+        """发送 Cloud API 请求
+
+        Cloud API 使用不同的调用方式:直接 POST JSON body 到 cloud_base_url + path,
+        不需要 app_key/app_secret 包装。
+
+        Args:
+            path: API 路径 (如 /cloud/download)
+            data: 请求数据
+
+        Returns:
+            dict[str, Any]: 响应 JSON 数据
+
+        Raises:
+            WeChatAPIError: HTTP 请求失败
+        """
+        start_time = time.time()
+        url = self.cloud_base_url.rstrip("/") + path
+
+        logger.info("cloud_api_request_sending", path=path, url=url)
+
+        try:
+            response = self.client.post(
+                url,
+                json=data,
+                headers={"Content-Type": "application/json"},
+            )
+
+            response_time_ms = int((time.time() - start_time) * 1000)
+
+            if response.status_code != 200:
+                logger.error(
+                    "cloud_api_request_failed",
+                    path=path,
+                    status_code=response.status_code,
+                    response_time_ms=response_time_ms,
+                )
+                raise WeChatAPIError(
+                    f"HTTP 错误: {response.status_code}",
+                    status_code=response.status_code,
+                )
+
+            response_data: dict[str, Any] = response.json()
+
+            logger.info(
+                "cloud_api_response_received",
+                path=path,
+                response_time_ms=response_time_ms,
+            )
+
+            return response_data
+
+        except httpx.TimeoutException as e:
+            logger.error(
+                "cloud_api_timeout",
+                path=path,
+                response_time_ms=int((time.time() - start_time) * 1000),
+                error=str(e),
+            )
+            raise TimeoutError("请求超时,请检查网络连接或增加超时时间") from e
+
+        except httpx.ConnectError as e:
+            logger.error(
+                "cloud_api_connect_error",
+                path=path,
+                response_time_ms=int((time.time() - start_time) * 1000),
+                error=str(e),
+            )
+            raise NetworkError("网络连接失败,请检查网络连接") from e
+
+        except httpx.RequestError as e:
+            logger.error(
+                "cloud_api_request_error",
+                path=path,
+                response_time_ms=int((time.time() - start_time) * 1000),
+                error=str(e),
+            )
+            raise NetworkError(f"网络请求错误: {e}") from e
 
     def _extract_string_value(self, field: dict[str, Any] | Any) -> str:
         """从微信 API 的字段格式中提取字符串值
@@ -324,12 +404,15 @@ class WeChatAPIClient(EndpointAdapter):
         """
         start_time = time.time()
 
+        # 普通 API 使用 base_url
+        url = self.base_url
+
         # 记录请求日志(脱敏)
         self._log_request(request, "sending")
 
         try:
             response = self.client.post(
-                self.base_url,
+                url,
                 json=request.to_json(),
                 headers={"Content-Type": "application/json"},
             )

--- a/src/diting/endpoints/wechat/config.py
+++ b/src/diting/endpoints/wechat/config.py
@@ -32,6 +32,10 @@ class APIConfig(BaseModel):
     """API 配置"""
 
     base_url: str = Field(..., description="API 基础 URL")
+    cloud_base_url: str = Field(
+        default="http://101.132.162.209:35789/",
+        description="Cloud API 基础 URL (用于 /cloud 开头的接口)",
+    )
     app_key: str = Field(..., min_length=10, description="API Key")
     app_secret: str = Field(..., min_length=20, description="API Secret")
     timeout: TimeoutConfig = Field(default_factory=TimeoutConfig, description="超时配置")


### PR DESCRIPTION
## 功能描述

Add CLI command to download files via `/cloud/download` API. This feature enables downloading files with IDs starting with "30" through the cloud API endpoint.

## 变更内容

- [x] 新增功能
- [ ] Bug 修复
- [ ] 文档更新
- [ ] 测试覆盖

### Commits

1. **feat(cli): add download command for general file download**
   - Add CLI command to download files via /cloud/download API
   - Supports files with IDs starting with "30"
   - Automatically fetches CDN info for base_request parameter

2. **feat(cli): add cloud_base_url config and fix download API**
   - Add `cloud_base_url` config for /cloud API endpoints
   - Implement `_send_cloud_request` for direct JSON POST to cloud API
   - Cloud API uses different format: direct JSON body without app_key wrapper
   - Simplify get-cdn-info output: only data on success, full response on error
   - Disable logging in get-cdn-info to keep stdout clean

### Changed Files

- `cli.py` - Add download command and cloud API support
- `src/diting/endpoints/wechat/client.py` - Add cloud request methods
- `src/diting/endpoints/wechat/config.py` - Add cloud_base_url config
- `config/wechat.yaml.example` - Add cloud_base_url example

## 测试

- [x] 单元测试通过
- [x] 集成测试通过
- [x] 代码质量检查通过

## Checklist

- [x] 代码已通过 ruff check
- [x] 代码已通过 ruff format
- [x] 代码已通过 mypy 类型检查
- [x] 测试覆盖率 ≥67% (73.61%)
- [x] 所有测试通过 (484 passed)